### PR TITLE
fix: remove "o eosc pl" from footer

### DIFF
--- a/ui/apps/ui/src/index.html
+++ b/ui/apps/ui/src/index.html
@@ -89,6 +89,5 @@
       terms-of-use="/terms-of-use"
       privacy-policy="/privacy-policy"
     ></EoscCommonMainFooter>
-    <EoscCommonEuInformation></EoscCommonEuInformation>
   </body>
 </html>


### PR DESCRIPTION
Closes #109 