### PR TITLE
style: RWD fix for Partners section

### DIFF
--- a/ui/apps/ui/src/app/pages/landing-page/landing-page.component.html
+++ b/ui/apps/ui/src/app/pages/landing-page/landing-page.component.html
@@ -24,7 +24,7 @@
 
   <section class="resource-categories">
     <div class="container">
-      <h3>What can you explore on our platform.</h3>
+      <h3>What can you explore on our platform?</h3>
 
       <div class="explore-wrapper">
 

--- a/ui/apps/ui/src/app/pages/landing-page/landing-page.component.html
+++ b/ui/apps/ui/src/app/pages/landing-page/landing-page.component.html
@@ -24,7 +24,7 @@
 
   <section class="resource-categories">
     <div class="container">
-      <h3>What can u explore on our platform.</h3>
+      <h3>What can you explore on our platform.</h3>
 
       <div class="explore-wrapper">
 

--- a/ui/apps/ui/src/scss/landing.scss
+++ b/ui/apps/ui/src/scss/landing.scss
@@ -1088,6 +1088,7 @@ h2 {
         height: 90px;
         display: flex;
         align-items: center;
+        justify-content: center;
 
         img {
           max-height: 120px;
@@ -1453,7 +1454,46 @@ footer {
   }
 }
 
+@media (max-width: 1200px) {
+
+  .partners .container {
+    flex-wrap: wrap;
+    gap: 40px;
+    row-gap: 50px;
+    justify-content: center;
+  }
+
+  .partners .container .partner-box {
+    width: 30%;
+  }
+
+  .partners .container .partner-box .partner-title {
+    font-size: 20px;
+  }
+
+  .partners .container .partner-box .partner-title br {
+    display: none;
+  }
+
+}
+
 @media (max-width: 768px) {
+
+  .partners .container {
+    justify-content: space-around;
+    flex-wrap: wrap;
+    gap: 0;
+    row-gap: 30px;
+  }
+
+  .partners .container .partner-box .partner-logo img {
+    max-height: 100px;
+    max-width: 90% !important;
+  }
+
+  .partners .container .partner-box {
+    width: 45%;
+  }
 
   .resource-categories {
     h3 {


### PR DESCRIPTION
Complex fix for Partner's logos on smaller screens:

<img width="1902" height="906" alt="image" src="https://github.com/user-attachments/assets/bfb5096e-d0c7-4361-a021-5c7bc10dc33b" />

<img width="1040" height="1012" alt="image" src="https://github.com/user-attachments/assets/a0e0c7ac-66c3-436a-8017-6e39f920acab" />
